### PR TITLE
Added `stripScheme` flag to comply with newer Docker config.json

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -34,7 +34,7 @@ func TestCreateDockerCfg(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := createDockerCfg(tc.tokenOutput)
+			_, err := createDockerCfg(tc.tokenOutput, false)
 			if err != nil {
 				if tc.success {
 					t.Fatal(err)


### PR DESCRIPTION
I'm using this with Flux, and I recently upgraded to the latest version.

It was having trouble authenticating, and I found out that the expectation for the URL in config.json is different now. Originally it included the scheme, now it no longer wants it.

I've added this `stripScheme` flag so it can be enabled, it strips out the scheme from the URL.

My old config.json would look like:
```
{
  "auths": {
	 "https://xxxxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com": {
	   "auth": "..."
	 }
  }
}
```

Now it looks like:
```
{
  "auths": {
	 "xxxxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com": {
	   "auth": "..."
	 }
  }
}```